### PR TITLE
Feature/13382 findtextblocks datatypes docs

### DIFF
--- a/content/en/docs/2023.11/Reference/Blocks/Text/find-text/find-all-text-block.md
+++ b/content/en/docs/2023.11/Reference/Blocks/Text/find-text/find-all-text-block.md
@@ -416,7 +416,7 @@ The [Text][Text Property] to find all occurrences of [Text To Find][TextToFind P
 | | |
 |--------------------|---------------------------|
 | Data Type | [String][] |
-| Property Type | [InputOutput][] |
+| Property Type | [Input][] |
 | Is [Advanced][] | `false` |
 | Default Editor | [Variable][] |
 | Default Value | `($)Text` with no value |

--- a/content/en/docs/2023.11/Reference/Blocks/Text/find-text/find-text-block.md
+++ b/content/en/docs/2023.11/Reference/Blocks/Text/find-text/find-text-block.md
@@ -475,7 +475,7 @@ For information about [supported values][Occurrences] for the [Occurrence][Occur
 | Property Type | [Input][] |
 | Is [Advanced][] | `false` |
 | Default Editor | [Literal][] |
-| Default Value | `0` |
+| Default Value | `1` |
 
 
 ### Search Options

--- a/content/en/docs/2023.11/Reference/Blocks/Text/find-text/find-text-block.md
+++ b/content/en/docs/2023.11/Reference/Blocks/Text/find-text/find-text-block.md
@@ -434,7 +434,7 @@ The [Text][Text Property] to find the specified occurrence of [Text To Find][Tex
 | | |
 |--------------------|---------------------------|
 | Data Type | [String][] |
-| Property Type | [InputOutput][] |
+| Property Type | [Input][] |
 | Is [Advanced][] | `false` |
 | Default Editor | [Variable][] |
 | Default Value | `($)Text` with no value |

--- a/content/en/docs/2023.11/Reference/data-types/text/regex/capturedetails.md
+++ b/content/en/docs/2023.11/Reference/data-types/text/regex/capturedetails.md
@@ -34,7 +34,7 @@ The value of this capture.
 | Data Type | [String][] |
 | Is [Advanced][] | `false` |
 | Default Editor | [Expression][] |
-| Default Value | `null` |
+| Default Value | [String][] with no value |
 
 ### Index
 

--- a/content/en/docs/2023.11/Reference/data-types/text/regex/capturedetails.md
+++ b/content/en/docs/2023.11/Reference/data-types/text/regex/capturedetails.md
@@ -8,8 +8,6 @@ description: "Used to represent a single capture for a given group"
 
 <p class="namespace">(Cortex.DataTypes.Text.Regex.CaptureDetails)</p>
 
-{{< workinprogress >}}
-
 ## Summary
 
 The `CaptureDetails` data type is used to represent a single capture for a given [Group][].

--- a/content/en/docs/2023.11/Reference/data-types/text/regex/capturedetails.md
+++ b/content/en/docs/2023.11/Reference/data-types/text/regex/capturedetails.md
@@ -12,26 +12,109 @@ description: "Used to represent a single capture for a given group"
 
 ## Summary
 
-## Properties
+The `CaptureDetails` data type is used to represent a single capture for a given [Group][].
 
-### Index
+| | |
+|-|-|
+| **Category:**          | Regex                                            |
+| **Name:**              | `CaptureDetails`                                      |
+| **Full Name:**         | `Cortex.DataTypes.Text.Regex.CaptureDetails`         |
+| **Alias:**             | N/A                                                    |
+| **Description:**       | A single capture for a given group. |
+| **Default Value:**     | null                                                   |
+| **Can be used as:**    | `CaptureDetails`, `Object`, `dynamic`                 |
+| **Can be cast to:**    | N/A                                                    |
+
+## Properties
 
 ### Value
 
+The value of this capture.
+
+| | |
+|--------------------|---------------------------|
+| Data Type | [String][] |
+| Is [Advanced][] | `false` |
+| Default Editor | [Expression][] |
+| Default Value | `null` |
+
+### Index
+
+The starting index of this capture in the input text.
+
+| | |
+|--------------------|---------------------------|
+| Data Type | [Int32][] |
+| Is [Advanced][] | `false` |
+| Default Editor | [Expression][] |
+| Default Value | [Int32][] with value `0` |
+
 ### Length
+
+The length of the capture.
+
+| | |
+|--------------------|---------------------------|
+| Data Type | [Int32][] |
+| Is [Advanced][] | `false` |
+| Default Editor | [Expression][] |
+| Default Value | [Int32][] with value `0` |
 
 ## Remarks
 
 ### Create a CaptureDetails
 
+The following table shows some of the ways that a `CaptureDetails` can be created.
+
+| Method | Example | Result | Editor&nbsp;Support | Notes |
+|-|-|-|-|-|
+| Construct `CaptureDetails` | `new CaptureDetails{Value = "", Index = 0, Length = 0}`  | `{"Value": "","Index": 0,"Length": 0}` | Expression | No proper constructor exists for this data type. |
+
+### Convert a Group to Text
+
+| Method | Example | Result | Editor&nbsp;Support | Notes |
+|-|-|-|-|-|
+| Use `Convert Object to Json` block | where `Object` property has a value of `{"Value": "","Index": 0,"Length": 0}` | `"{\r\n  \"Value\": \"\",\r\n  \"Index\": 0,\r\n  \"Length\": 0\r\n}"` | N/A | See [Convert Object to Json][] |
+
 ### Property Editor Support
 
+- The Expression Editor is available for [Input][] properties where the data type is `CaptureDetails`.
+- The Literal Editor is available for [Input][] properties where the data type is `CaptureDetails`.
+- The Variable Editor is available for [Input][], [InputOutput][] and [Output][] properties where the data type is `CaptureDetails`.
+
 ### Known Limitations
+
+None
 
 ## See Also
 
 ### Related Data Types
 
+* [Group][]
+* [Int32][]
+* [String][]
+
 ### Related Concepts
 
+* [Working with Text][]
+
 ### External Documentation
+
+* [System.Text.RegularExpressions.Capture][]
+
+[Input]: {{< url path="Cortex.Reference.Concepts.Fundamentals.Blocks.BlockProperties.WhatIsABlockProperty.Input" >}}
+[Output]: {{< url path="Cortex.Reference.Concepts.Fundamentals.Blocks.BlockProperties.WhatIsABlockProperty.Output" >}}
+[InputOutput]: {{< url path="Cortex.Reference.Concepts.Fundamentals.Blocks.BlockProperties.WhatIsABlockProperty.InputOutput" >}}
+[Expression]: {{< url path="Cortex.Reference.Concepts.Fundamentals.Blocks.BlockProperties.PropertyEditors.ExpressionEditor.MainDoc" >}}
+[Literal]: {{< url path="Cortex.Reference.Concepts.Fundamentals.Blocks.BlockProperties.PropertyEditors.LiteralEditor.MainDoc" >}}
+[Advanced]: {{< url path="Cortex.Reference.Concepts.Fundamentals.Blocks.BlockProperties.AdvancedProperties.MainDoc" >}}
+
+[System.Text.RegularExpressions.Capture]: {{< url path="MSDocs.DotNet.Api.System.Text.RegularExpressions.Capture" >}}
+
+[Group]: {{<url path="Cortex.Reference.DataTypes.Text.Regex.Group.MainDoc">}}
+[Int32]: {{<url path="Cortex.Reference.DataTypes.Numbers.Int32.MainDoc">}}
+[String]: {{< url path="Cortex.Reference.DataTypes.Text.String.MainDoc" >}}
+
+[Convert Object To Json]: {{< url path="Cortex.Reference.Blocks.Json.ConvertJson.ConvertObjectToJson.MainDoc" >}}
+
+[Working with Text]: {{< url path="Cortex.Reference.Concepts.WorkingWith.Text.MainDoc" >}}

--- a/content/en/docs/2023.11/Reference/data-types/text/regex/group.md
+++ b/content/en/docs/2023.11/Reference/data-types/text/regex/group.md
@@ -12,28 +12,120 @@ description: "Used to represent a regex match group. It contains all of the capt
 
 ## Summary
 
+The `Group` data type is used to represent a regex match group. It contains all of the [Captures][CaptureDetails] for a given group pattern.
+
+| | |
+|-|-|
+| **Category:**          | Regex                                            |
+| **Name:**              | `Group`                                      |
+| **Full Name:**         | `Cortex.DataTypes.Text.Regex.Group`         |
+| **Alias:**             | N/A                                                    |
+| **Description:**       | A regex match group. |
+| **Default Value:**     | null                                                   |
+| **Can be used as:**    | `Group`, `Object`, `dynamic`                 |
+| **Can be cast to:**    | N/A                                                    |
+
 ## Properties
 
 ### Value
 
+The Value is the matched [String][] of the regex match group.
+
+| | |
+|--------------------|---------------------------|
+| Data Type | [String][] |
+| Is [Advanced][] | `false` |
+| Default Editor | [Expression][] |
+| Default Value | `null` |
+
 ### Index
+
+The index in the source text at which the regex match group starts.
+
+| | |
+|--------------------|---------------------------|
+| Data Type | [Int32][] |
+| Is [Advanced][] | `false` |
+| Default Editor | [Expression][] |
+| Default Value | [Int32][] with value `0` |
 
 ### Length
 
+The length of this regex match's value.
+
+| | |
+|--------------------|---------------------------|
+| Data Type | [Int32][] |
+| Is [Advanced][] | `false` |
+| Default Editor | [Expression][] |
+| Default Value | [Int32][] with value `0` |
+
 ### Captures
+
+The list of [Captures][CaptureDetails] for this regex match group.
+
+| | |
+|--------------------|---------------------------|
+| Data Type | IReadOnlyList<[CaptureDetails][]> |
+| Is [Advanced][] | `false` |
+| Default Editor | [Expression][] |
+| Default Value | `null` |
 
 ## Remarks
 
 ### Create a Group
 
+The following table shows some of the ways that a `Group` can be created.
+
+| Method | Example | Result | Editor&nbsp;Support | Notes |
+|-|-|-|-|-|
+| Construct `Match` | `new Group{Value = "", Index = 0, Length = 0, Captures = new List<CaptureDetails>()}`  | `{"Value": "","Index": 0,"Length": 0,"Captures": []}` | Expression | No proper constructor exists for this data type. |
+
+### Convert a Group to Text
+
+| Method | Example | Result | Editor&nbsp;Support | Notes |
+|-|-|-|-|-|
+| Use `Convert Object to Json` block | where `Object` property has a value of `{"Value": "","Index": 0,"Length": 0,"Captures": []}` | `"{\r\n  \"Value\": \"\",\r\n  \"Index\": 0,\r\n  \"Length\": 0,\r\n  \"Captures\": []\r\n}"` | N/A | See [Convert Object to Json][] |
+
 ### Property Editor Support
 
+- The Expression Editor is available for [Input][] properties where the data type is `Match`.
+- The Literal Editor is available for [Input][] properties where the data type is `Match`.
+- The Variable Editor is available for [Input][], [InputOutput][] and [Output][] properties where the data type is `Match`.
+
 ### Known Limitations
+
+None
 
 ## See Also
 
 ### Related Data Types
 
+* [CaptureDetails][]
+* IReadOnlyList
+* [Int32][]
+* [String][]
+
 ### Related Concepts
 
+* [Working with Text][]
+
 ### External Documentation
+
+* [System.Text.RegularExpressions.Group][]
+
+[Input]: {{< url path="Cortex.Reference.Concepts.Fundamentals.Blocks.BlockProperties.WhatIsABlockProperty.Input" >}}
+[Output]: {{< url path="Cortex.Reference.Concepts.Fundamentals.Blocks.BlockProperties.WhatIsABlockProperty.Output" >}}
+[InputOutput]: {{< url path="Cortex.Reference.Concepts.Fundamentals.Blocks.BlockProperties.WhatIsABlockProperty.InputOutput" >}}
+[Expression]: {{< url path="Cortex.Reference.Concepts.Fundamentals.Blocks.BlockProperties.PropertyEditors.ExpressionEditor.MainDoc" >}}
+[Literal]: {{< url path="Cortex.Reference.Concepts.Fundamentals.Blocks.BlockProperties.PropertyEditors.LiteralEditor.MainDoc" >}}
+[Advanced]: {{< url path="Cortex.Reference.Concepts.Fundamentals.Blocks.BlockProperties.AdvancedProperties.MainDoc" >}}
+
+[System.Text.RegularExpressions.Group]: {{< url path="MSDocs.DotNet.Api.System.Text.RegularExpressions.Group" >}}
+
+[CaptureDetails]: {{<url path="Cortex.Reference.DataTypes.Text.Regex.CaptureDetails.MainDoc">}}
+[Dictionary]: {{<url path="Cortex.Reference.DataTypes.Collections.Dictionary.MainDoc">}}
+[Int32]: {{<url path="Cortex.Reference.DataTypes.Numbers.Int32.MainDoc">}}
+[String]: {{< url path="Cortex.Reference.DataTypes.Text.String.MainDoc" >}}
+
+[Convert Object To Json]: {{< url path="Cortex.Reference.Blocks.Json.ConvertJson.ConvertObjectToJson.MainDoc" >}}

--- a/content/en/docs/2023.11/Reference/data-types/text/regex/group.md
+++ b/content/en/docs/2023.11/Reference/data-types/text/regex/group.md
@@ -12,7 +12,7 @@ description: "Used to represent a regex match group. It contains all of the capt
 
 ## Summary
 
-The `Group` data type is used to represent a regex match group. It contains all of the [Captures][CaptureDetails] for a given group pattern.
+The `Group` data type is used to represent a [regex match][Match] group. It contains all of the [Captures][CaptureDetails] for a given group pattern.
 
 | | |
 |-|-|
@@ -126,6 +126,9 @@ None
 [CaptureDetails]: {{<url path="Cortex.Reference.DataTypes.Text.Regex.CaptureDetails.MainDoc">}}
 [Dictionary]: {{<url path="Cortex.Reference.DataTypes.Collections.Dictionary.MainDoc">}}
 [Int32]: {{<url path="Cortex.Reference.DataTypes.Numbers.Int32.MainDoc">}}
+[Match]: {{<url path="Cortex.Reference.DataTypes.Text.Regex.Match.MainDoc">}}
 [String]: {{< url path="Cortex.Reference.DataTypes.Text.String.MainDoc" >}}
 
 [Convert Object To Json]: {{< url path="Cortex.Reference.Blocks.Json.ConvertJson.ConvertObjectToJson.MainDoc" >}}
+
+[Working with Text]: {{< url path="Cortex.Reference.Concepts.WorkingWith.Text.MainDoc" >}}

--- a/content/en/docs/2023.11/Reference/data-types/text/regex/group.md
+++ b/content/en/docs/2023.11/Reference/data-types/text/regex/group.md
@@ -29,7 +29,7 @@ The `Group` data type is used to represent a regex match group. It contains all 
 
 ### Value
 
-The Value is the matched [String][] of the regex match group.
+The Value is the value of the last [capture][CaptureDetails] for this group.
 
 | | |
 |--------------------|---------------------------|
@@ -40,7 +40,7 @@ The Value is the matched [String][] of the regex match group.
 
 ### Index
 
-The index in the source text at which the regex match group starts.
+The starting index of the first [capture][CaptureDetails] for this group in the input text.
 
 | | |
 |--------------------|---------------------------|
@@ -51,7 +51,7 @@ The index in the source text at which the regex match group starts.
 
 ### Length
 
-The length of this regex match's value.
+The length of the matched group text.
 
 | | |
 |--------------------|---------------------------|
@@ -62,7 +62,7 @@ The length of this regex match's value.
 
 ### Captures
 
-The list of [Captures][CaptureDetails] for this regex match group.
+The list of [captures][CaptureDetails] found for this regex match group. If there were no captures, this is an empty list.
 
 | | |
 |--------------------|---------------------------|

--- a/content/en/docs/2023.11/Reference/data-types/text/regex/group.md
+++ b/content/en/docs/2023.11/Reference/data-types/text/regex/group.md
@@ -34,7 +34,7 @@ The Value is the value of the last [capture][CaptureDetails] for this group.
 | Data Type | [String][] |
 | Is [Advanced][] | `false` |
 | Default Editor | [Expression][] |
-| Default Value | `null` |
+| Default Value | [String][] with no value. |
 
 ### Index
 
@@ -67,7 +67,7 @@ The list of [captures][CaptureDetails] found for this regex match group. If ther
 | Data Type | IReadOnlyList<[CaptureDetails][]> |
 | Is [Advanced][] | `false` |
 | Default Editor | [Expression][] |
-| Default Value | `null` |
+| Default Value | IReadOnlyList<[CaptureDetails][]> with no value |
 
 ## Remarks
 

--- a/content/en/docs/2023.11/Reference/data-types/text/regex/group.md
+++ b/content/en/docs/2023.11/Reference/data-types/text/regex/group.md
@@ -79,7 +79,7 @@ The following table shows some of the ways that a `Group` can be created.
 
 | Method | Example | Result | Editor&nbsp;Support | Notes |
 |-|-|-|-|-|
-| Construct `Match` | `new Group{Value = "", Index = 0, Length = 0, Captures = new List<CaptureDetails>()}`  | `{"Value": "","Index": 0,"Length": 0,"Captures": []}` | Expression | No proper constructor exists for this data type. |
+| Construct `Group` | `new Group{Value = "", Index = 0, Length = 0, Captures = new List<CaptureDetails>()}`  | `{"Value": "","Index": 0,"Length": 0,"Captures": []}` | Expression | No proper constructor exists for this data type. |
 
 ### Convert a Group to Text
 

--- a/content/en/docs/2023.11/Reference/data-types/text/regex/group.md
+++ b/content/en/docs/2023.11/Reference/data-types/text/regex/group.md
@@ -89,9 +89,9 @@ The following table shows some of the ways that a `Group` can be created.
 
 ### Property Editor Support
 
-- The Expression Editor is available for [Input][] properties where the data type is `Match`.
-- The Literal Editor is available for [Input][] properties where the data type is `Match`.
-- The Variable Editor is available for [Input][], [InputOutput][] and [Output][] properties where the data type is `Match`.
+- The Expression Editor is available for [Input][] properties where the data type is `Group`.
+- The Literal Editor is available for [Input][] properties where the data type is `Group`.
+- The Variable Editor is available for [Input][], [InputOutput][] and [Output][] properties where the data type is `Group`.
 
 ### Known Limitations
 

--- a/content/en/docs/2023.11/Reference/data-types/text/regex/group.md
+++ b/content/en/docs/2023.11/Reference/data-types/text/regex/group.md
@@ -8,8 +8,6 @@ description: "Used to represent a regex match group. It contains all of the capt
 
 <p class="namespace">(Cortex.DataTypes.Text.Regex.Group)</p>
 
-{{< workinprogress >}}
-
 ## Summary
 
 The `Group` data type is used to represent a [regex match][Match] group. It contains all of the [Captures][CaptureDetails] for a given group pattern.

--- a/content/en/docs/2023.11/Reference/data-types/text/regex/group.md
+++ b/content/en/docs/2023.11/Reference/data-types/text/regex/group.md
@@ -104,6 +104,7 @@ None
 * [CaptureDetails][]
 * IReadOnlyList
 * [Int32][]
+* [Match][]
 * [String][]
 
 ### Related Concepts

--- a/content/en/docs/2023.11/Reference/data-types/text/regex/match.md
+++ b/content/en/docs/2023.11/Reference/data-types/text/regex/match.md
@@ -8,32 +8,125 @@ description: "Used to represent a regex match. It contains all of the groups fou
 
 <p class="namespace">(Cortex.DataTypes.Text.Regex.Match)</p>
 
-{{< workinprogress >}}
+{{<workinprogress>}}
 
 ## Summary
+
+The `Match` data type is used to represent a regex match. It contains all of the [Groups][Group] found in the regex pattern.
+
+| | |
+|-|-|
+| **Category:**          | Regex                                            |
+| **Name:**              | `Match`                                      |
+| **Full Name:**         | `Cortex.DataTypes.Text.Regex.Match`         |
+| **Alias:**             | N/A                                                    |
+| **Description:**       | A regex match. |
+| **Default Value:**     | null                                                   |
+| **Can be used as:**    | `Match`, `Object`, `dynamic`                 |
+| **Can be cast to:**    | N/A                                                    |
 
 ## Properties
 
 ### Value
 
+The Value is the matched [String][] of the regex match.
+
+| | |
+|--------------------|---------------------------|
+| Data Type | [String][] |
+| Is [Advanced][] | `false` |
+| Default Editor | [Expression][] |
+| Default Value | `null` |
+
 ### Index
+
+The index in the source text at which the regex match starts.
+
+| | |
+|--------------------|---------------------------|
+| Data Type | [Int32][] |
+| Is [Advanced][] | `false` |
+| Default Editor | [Expression][] |
+| Default Value | `null` |
 
 ### Length
 
+The length of this regex match's value.
+
+| | |
+|--------------------|---------------------------|
+| Data Type | [Int32][] |
+| Is [Advanced][] | `false` |
+| Default Editor | [Expression][] |
+| Default Value | `null` |
+
 ### Groups
+
+The dictionary of [Groups][Group] in this match. The default group `0` is always included for a valid match, and contains the whole [Value][Value Property] as its value.
+
+| | |
+|--------------------|---------------------------|
+| Data Type | [Dictionary][]<[String][], [Group][]> |
+| Is [Advanced][] | `false` |
+| Default Editor | [Expression][] |
+| Default Value | `null` |
 
 ## Remarks
 
 ### Create a Match
 
+The following table shows some of the ways that a `Match` can be created.
+
+| Method | Example | Result | Editor&nbsp;Support | Notes |
+|-|-|-|-|-|
+| Construct `Match` | `new Match{Value = "", Index = 0, Length = 0, Groups = {}}`  | `{"Value": "","Index": 0,"Length": 0,"Groups": {}}` | Expression | No constructor exists for this data type. |
+
+### Convert Match to Text
+
+| Method | Example | Result | Editor&nbsp;Support | Notes |
+|-|-|-|-|-|
+| Use `Convert Object to Json` block | where `Object` property has a value of `{"Value": "","Index": 0,"Length": 0,"Groups": {}}` | `{"Value": "","Index": 0,"Length": 0,"Groups": {}}` | N/A | See [Convert Object to Json] |
+
 ### Property Editor Support
 
+- The Expression Editor is available for [Input][] properties where the data type is `Match`.
+- The Variable Editor is available for [Input][], [InputOutput][] and [Output][] properties where the data type is `Match`.
+
 ### Known Limitations
+
+None
 
 ## See Also
 
 ### Related Data Types
 
+* [Dictionary][]
+* [Group][]
+* [Int32][]
+* [String][]
+
 ### Related Concepts
 
+* [Working with Text][]
+
 ### External Documentation
+
+* [System.Text.RegularExpressions.Match][]
+
+[Value Property]: {{#ref "#value"}}
+
+[Input]: {{< url path="Cortex.Reference.Concepts.Fundamentals.Blocks.BlockProperties.WhatIsABlockProperty.Input" >}}
+[Output]: {{< url path="Cortex.Reference.Concepts.Fundamentals.Blocks.BlockProperties.WhatIsABlockProperty.Output" >}}
+[InputOutput]: {{< url path="Cortex.Reference.Concepts.Fundamentals.Blocks.BlockProperties.WhatIsABlockProperty.InputOutput" >}}
+[Expression]: {{< url path="Cortex.Reference.Concepts.Fundamentals.Blocks.BlockProperties.PropertyEditors.ExpressionEditor.MainDoc" >}}
+[Literal]: {{< url path="Cortex.Reference.Concepts.Fundamentals.Blocks.BlockProperties.PropertyEditors.LiteralEditor.MainDoc" >}}
+[Advanced]: {{< url path="Cortex.Reference.Concepts.Fundamentals.Blocks.BlockProperties.AdvancedProperties.MainDoc" >}}
+
+[System.Text.RegularExpressions.Match]: {{< url path="MSDocs.DotNet.Api.System.Text.RegularExpressions.Match" >}}
+
+[Dictionary]: {{<url path="Cortex.Reference.DataTypes.Collections.Dictionary.MainDoc">}}
+[Int32]: {{<url path="Cortex.Reference.DataTypes.Numbers.Int32.MainDoc">}}
+[String]: {{< url path="Cortex.Reference.DataTypes.Text.String.MainDoc" >}}
+[Group]: {{<url path="Cortex.Reference.DataTypes.Text.Regex.Group.MainDoc">}}
+
+[Convert Object To Json]: {{< url path="Cortex.Reference.Blocks.Json.ConvertJson.ConvertObjectToJson.MainDoc" >}}

--- a/content/en/docs/2023.11/Reference/data-types/text/regex/match.md
+++ b/content/en/docs/2023.11/Reference/data-types/text/regex/match.md
@@ -34,7 +34,7 @@ The value of the full match.
 | Data Type | [String][] |
 | Is [Advanced][] | `false` |
 | Default Editor | [Expression][] |
-| Default Value | `null` |
+| Default Value | [String][] with no value |
 
 ### Index
 
@@ -112,7 +112,7 @@ None
 
 * [System.Text.RegularExpressions.Match][]
 
-[Value Property]: {{#ref "#value"}}
+[Value Property]: {{<ref "#value">}}
 
 [Input]: {{< url path="Cortex.Reference.Concepts.Fundamentals.Blocks.BlockProperties.WhatIsABlockProperty.Input" >}}
 [Output]: {{< url path="Cortex.Reference.Concepts.Fundamentals.Blocks.BlockProperties.WhatIsABlockProperty.Output" >}}

--- a/content/en/docs/2023.11/Reference/data-types/text/regex/match.md
+++ b/content/en/docs/2023.11/Reference/data-types/text/regex/match.md
@@ -47,7 +47,7 @@ The index in the source text at which the regex match starts.
 | Data Type | [Int32][] |
 | Is [Advanced][] | `false` |
 | Default Editor | [Expression][] |
-| Default Value | `null` |
+| Default Value | [Int32][] with value `0` |
 
 ### Length
 
@@ -58,18 +58,18 @@ The length of this regex match's value.
 | Data Type | [Int32][] |
 | Is [Advanced][] | `false` |
 | Default Editor | [Expression][] |
-| Default Value | `null` |
+| Default Value | [Int32][] with value `0` |
 
 ### Groups
 
-The dictionary of [Groups][Group] in this match. The default group `0` is always included for a valid match, and contains the whole [Value][Value Property] as its value.
+The dictionary of [Groups][Group] in this match. The key [String][] is the [Group][] name. The default group `0` is always included for a valid match, and contains the whole [Value][Value Property] as its value.
 
 | | |
 |--------------------|---------------------------|
 | Data Type | [Dictionary][]<[String][], [Group][]> |
 | Is [Advanced][] | `false` |
 | Default Editor | [Expression][] |
-| Default Value | `null` |
+| Default Value | [Dictionary][]<[String][], [Group][]> with value `{}` |
 
 ## Remarks
 

--- a/content/en/docs/2023.11/Reference/data-types/text/regex/match.md
+++ b/content/en/docs/2023.11/Reference/data-types/text/regex/match.md
@@ -29,7 +29,7 @@ The `Match` data type is used to represent a regex match. It contains all of the
 
 ### Value
 
-The Value is the matched [String][] of the regex match.
+The value of the full match.
 
 | | |
 |--------------------|---------------------------|
@@ -40,7 +40,7 @@ The Value is the matched [String][] of the regex match.
 
 ### Index
 
-The index in the source text at which the regex match starts.
+The starting index of the regex match in the input text.
 
 | | |
 |--------------------|---------------------------|
@@ -51,7 +51,7 @@ The index in the source text at which the regex match starts.
 
 ### Length
 
-The length of this regex match's value.
+The length of this regex match.
 
 | | |
 |--------------------|---------------------------|
@@ -62,7 +62,7 @@ The length of this regex match's value.
 
 ### Groups
 
-The dictionary of [Groups][Group] in this match. The key [String][] is the [Group][] name. The default group `0` is always included for a valid match, and contains the whole [Value][Value Property] as its value.
+The dictionary of [Groups][Group] in this match. The key [String][] is the [Group][] name. The default group `0` is always included for a valid match, and contains the whole [Value][Value Property] as its value. Unnamed groups will have keys starting from `"1"`, `"2"`, etc.
 
 | | |
 |--------------------|---------------------------|

--- a/content/en/docs/2023.11/Reference/data-types/text/regex/match.md
+++ b/content/en/docs/2023.11/Reference/data-types/text/regex/match.md
@@ -79,17 +79,18 @@ The following table shows some of the ways that a `Match` can be created.
 
 | Method | Example | Result | Editor&nbsp;Support | Notes |
 |-|-|-|-|-|
-| Construct `Match` | `new Match{Value = "", Index = 0, Length = 0, Groups = {}}`  | `{"Value": "","Index": 0,"Length": 0,"Groups": {}}` | Expression | No constructor exists for this data type. |
+| Construct `Match` | `new Match{Value = "", Index = 0, Length = 0, Groups = {}}`  | `{"Value": "","Index": 0,"Length": 0,"Groups": {}}` | Expression | |
 
 ### Convert Match to Text
 
 | Method | Example | Result | Editor&nbsp;Support | Notes |
 |-|-|-|-|-|
-| Use `Convert Object to Json` block | where `Object` property has a value of `{"Value": "","Index": 0,"Length": 0,"Groups": {}}` | `{"Value": "","Index": 0,"Length": 0,"Groups": {}}` | N/A | See [Convert Object to Json] |
+| Use `Convert Object to Json` block | where `Object` property has a value of `{"Value": "","Index": 0,"Length": 0,"Groups": {}}` | `"{\r\n  \"Value\": \"\",\r\n  \"Index\": 0,\r\n  \"Length\": 0,\r\n  \"Groups\": {}\r\n}"` | N/A | See [Convert Object to Json][] |
 
 ### Property Editor Support
 
 - The Expression Editor is available for [Input][] properties where the data type is `Match`.
+- The Literal Editor is available for [Input][] properties where the data type is `Match`.
 - The Variable Editor is available for [Input][], [InputOutput][] and [Output][] properties where the data type is `Match`.
 
 ### Known Limitations

--- a/content/en/docs/2023.11/Reference/data-types/text/regex/match.md
+++ b/content/en/docs/2023.11/Reference/data-types/text/regex/match.md
@@ -131,3 +131,5 @@ None
 [Group]: {{<url path="Cortex.Reference.DataTypes.Text.Regex.Group.MainDoc">}}
 
 [Convert Object To Json]: {{< url path="Cortex.Reference.Blocks.Json.ConvertJson.ConvertObjectToJson.MainDoc" >}}
+
+[Working with Text]: {{< url path="Cortex.Reference.Concepts.WorkingWith.Text.MainDoc" >}}

--- a/content/en/docs/2023.11/Reference/data-types/text/regex/match.md
+++ b/content/en/docs/2023.11/Reference/data-types/text/regex/match.md
@@ -8,8 +8,6 @@ description: "Used to represent a regex match. It contains all of the groups fou
 
 <p class="namespace">(Cortex.DataTypes.Text.Regex.Match)</p>
 
-{{<workinprogress>}}
-
 ## Summary
 
 The `Match` data type is used to represent a regex match. It contains all of the [Groups][Group] found in the regex pattern.

--- a/data/urls.toml
+++ b/data/urls.toml
@@ -2369,6 +2369,9 @@
         [MSDocs.DotNet.Api.System.Globalization]
             CultureInfo = "https://learn.microsoft.com/en-us/dotnet/api/system.globalization.cultureinfo"
         [MSDocs.DotNet.Api.System.Text.RegularExpressions]
+            Capture = "https://learn.microsoft.com/en-us/dotnet/api/system.text.regularexpressions.capture"
+            Group = "https://learn.microsoft.com/en-us/dotnet/api/system.text.regularexpressions.group"
+            Match = "https://learn.microsoft.com/en-us/dotnet/api/system.text.regularexpressions.match"
             RegexMatchTimeoutException = "https://learn.microsoft.com/en-us/dotnet/api/system.text.regularexpressions.regexmatchtimeoutexception"
         [MSDocs.DotNet.Api.System.Net]
             NetworkCredential = "https://learn.microsoft.com/en-us/dotnet/api/system.net.networkcredential"


### PR DESCRIPTION
Fix occurrence logic in `FindTextBlock`.
Add documentation to fix stub docs for `Cortex.DataTypes.Text.Regex` data types.